### PR TITLE
Fix Lucid looking for incorrect controller class name

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -1,11 +1,12 @@
 <?php
 
 require LUCID . 'database.php';
+require_once LUCID . 'casing.php';
 
 class Model {
     private static function table(): string {
 		$class = static::class;
-        return strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $class));
+        return Casing::pascal_to_snake($class);
     }
 
     private static function model(): string {

--- a/src/casing.php
+++ b/src/casing.php
@@ -1,0 +1,11 @@
+<?php
+
+abstract class Casing {
+    public static function snake_to_pascal(string $name): string {
+        return str_replace('_', '', ucwords($name, '_'));
+    }
+
+    public static function pascal_to_snake(string $name): string {
+        return strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $name));
+    }
+}

--- a/src/lucid.php
+++ b/src/lucid.php
@@ -5,6 +5,8 @@ define('APP', $lucid_app . '/');
 
 $routes = require APP . '/routes.php';
 
+require_once LUCID . 'casing.php';
+
 $resource = '';
 $action = NULL;
 $args = [];
@@ -27,7 +29,7 @@ $controller_path = APP . '/controllers/' . $resource . '_controller.php';
 if (file_exists($controller_path)) {
 	require $controller_path;
 
-	$controller_name = ucfirst($resource).'Controller';
+	$controller_name = Casing::snake_to_pascal($resource).'Controller';
 	$controller = new $controller_name();
 
 	if (!isset($action)) {


### PR DESCRIPTION
Fixes a bug where Lucid would only uppercase the first word when transforming a controller path to a class name, e.g., `product_brand_controller` became `Product_brandController`. This has been fixed and it now searches for the class `ProductBrandController`.