### PR TITLE
Add model update method

### DIFF
--- a/cli/base_project/controllers/page_controller.php
+++ b/cli/base_project/controllers/page_controller.php
@@ -3,7 +3,7 @@
 require LUCID . 'view.php';
 
 class PageController {
-	function index() {
+	public function index() {
 		view('Page/home.php');
 	}
 }

--- a/example/controllers/page_controller.php
+++ b/example/controllers/page_controller.php
@@ -3,11 +3,11 @@
 require LUCID . 'view.php';
 
 class PageController {
-	function index() {
+	public function index() {
 		view('Page/home.php');
 	}
 
-	function about() {
+	public function about() {
 		view('Page/about.php');
 	}
 }

--- a/example/controllers/post_controller.php
+++ b/example/controllers/post_controller.php
@@ -6,16 +6,20 @@ require ROOT . '/models/Post.php';
 class PostController {
     function index() {
         $posts = Post::all();
-		view('Post/index.php', ['posts' => $posts]);
+        view('Post/index.php', ['posts' => $posts]);
     }
 
     function show(int $post_id) {
         $post = Post::find(['post_id' => $post_id]);
-		view('Post/show.php', ['post' => $post]);
+        view('Post/show.php', ['post' => $post]);
     }
 
     function new() {
-		view('Post/new.php');
+        view('Post/new.php');
+    }
+
+    function edit(int $post_id) {
+        view('Post/edit.php');
     }
 
     function create() {
@@ -26,6 +30,16 @@ class PostController {
         $post_id = $post->post_id;
 
         header("Location: $post_id");
+    }
+
+    function update(int $post_id) {
+        $title = $_POST['title'];
+        $text = $_POST['text'];
+
+        $post = Post::find(['post_id' => $post_id]);
+        $post->update(['title' => $title, 'text' => $text]);
+
+        header("Location: ../$post_id");
     }
 
     function destroy(int $post_id) {

--- a/example/controllers/post_controller.php
+++ b/example/controllers/post_controller.php
@@ -4,25 +4,25 @@ require LUCID . 'view.php';
 require ROOT . '/models/Post.php';
 
 class PostController {
-    function index() {
+    public function index() {
         $posts = Post::all();
         view('Post/index.php', ['posts' => $posts]);
     }
 
-    function show(int $post_id) {
+    public function show(int $post_id) {
         $post = Post::find(['post_id' => $post_id]);
         view('Post/show.php', ['post' => $post]);
     }
 
-    function new() {
+    public function new() {
         view('Post/new.php');
     }
 
-    function edit(int $post_id) {
+    public function edit(int $post_id) {
         view('Post/edit.php');
     }
 
-    function create() {
+    public function create() {
         $title = $_POST['title'];
         $text = $_POST['text'];
 
@@ -32,7 +32,7 @@ class PostController {
         header("Location: $post_id");
     }
 
-    function update(int $post_id) {
+    public function update(int $post_id) {
         $title = $_POST['title'];
         $text = $_POST['text'];
 
@@ -42,7 +42,7 @@ class PostController {
         header("Location: ../$post_id");
     }
 
-    function destroy(int $post_id) {
+    public function destroy(int $post_id) {
         Post::delete(['post_id' => $post_id]);
 
         header("Location: ../../post");

--- a/example/routes.php
+++ b/example/routes.php
@@ -3,12 +3,14 @@
 require LUCID . 'routing.php';
 
 return [
-	route() => 'page',
-	route('home') => 'page',
-	route('about') => 'page@about',
-	route('post') => 'post',
-	route('post', '(?<post_id>\d+)') => 'post@show',
-	route('post', 'new') => 'post@new',
-	route('post', 'create') => 'post@create',
-	route('post', '(?<post_id>\d+)', 'destroy') => 'post@destroy',
+    route() => 'page',
+    route('home') => 'page',
+    route('about') => 'page@about',
+    route('post') => 'post',
+    route('post', '(?<post_id>\d+)') => 'post@show',
+    route('post', 'new') => 'post@new',
+    route('post', '(?<post_id>\d+)', 'edit') => 'post@edit',
+    route('post', 'create') => 'post@create',
+    route('post', '(?<post_id>\d+)', 'update') => 'post@update',
+    route('post', '(?<post_id>\d+)', 'destroy') => 'post@destroy',
 ];

--- a/example/views/Post/edit.php
+++ b/example/views/Post/edit.php
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<h1>Create new post</h1>
+<form action="update" method="POST">
+    <label>Title: </label><br>
+    <input name="title"><br>
+    <label>Text: </label><br>
+    <textarea name="text"></textarea>
+    <br><br>
+    <input type="submit", value="Submit">
+</form>
+<a href="../post">Back to all posts</a>
+</body>
+</html>

--- a/example/views/Post/show.php
+++ b/example/views/Post/show.php
@@ -6,6 +6,7 @@
 <h1><?= $post->title ?></h1>
 <p><?= $post->text ?></p>
 <a href=<?="./{$post->post_id}/destroy"?>>Delete</a>
+<a href=<?="./{$post->post_id}/edit"?>>Edit</a>
 <a href="../post">Back to all posts</a>
 </body>
 </html>

--- a/src/Model.php
+++ b/src/Model.php
@@ -13,6 +13,27 @@ class Model {
 		return static::class;
     }
 
+    public function update(array $params): void {
+        $param_columns = array_keys($params);
+        $param_values = array_values($params);
+
+        $updates = [];
+        foreach ($param_columns as $column) {
+            $updates[] = "{$column} = ?";
+        }
+
+        $set = implode(", ", $updates);
+
+        $table = static::table();
+        $primary_key = static::primary_key();
+        $primary_key_value = $this->get_primary_key();
+        DB::query("
+            UPDATE {$table}
+               SET {$set}
+             WHERE {$primary_key} = {$primary_key_value}
+        ");
+    }
+
     public static function all(): array {
         $table = static::table();
         $stmt = DB::query("

--- a/src/Model.php
+++ b/src/Model.php
@@ -31,19 +31,26 @@ class Model {
     }
 
     public function update(array $params): void {
+        $param_columns = array_keys($params);
+        $param_values = array_values($params);
+
         $updates_list = [];
-        foreach ($params as $column => $value) {
-            $updates_list[] = "{$column} = {$value}";
+        foreach ($param_columns as $column) {
+            $updates_list[] = "{$column} = ?";
         }
         $updates = implode(", ", $updates_list);
+
+        if (empty($updates)) {
+            return;
+        }
 
         $table = static::table();
         $primary_key = static::primary_key();
         DB::query("
             UPDATE {$table}
                SET {$updates}
-             WHERE {$primary_key} = :primary_key
-        ", primary_key: $this->get_primary_key());
+             WHERE {$primary_key} = ?;
+        ", ...[...$param_values, $this->get_primary_key()]);
     }
 
     public static function all(): array {

--- a/src/Model.php
+++ b/src/Model.php
@@ -43,7 +43,7 @@ class Model {
             UPDATE {$table}
                SET {$updates}
              WHERE {$primary_key} = :primary_key
-        ", ['primary_key' => $this->get_primary_key()]);
+        ", primary_key: $this->get_primary_key());
     }
 
     public static function all(): array {

--- a/src/lucid.php
+++ b/src/lucid.php
@@ -11,7 +11,11 @@ $resource = '';
 $action = NULL;
 $args = [];
 
-$url = $_SERVER['PATH_INFO'] ?? '/';
+if (isset($USE_RELATIVE_PATH_INFO)) {
+    $url = $_SERVER['PATH_INFO'] ?? '/';
+} else {
+    $url = $_SERVER['REQUEST_URI'] ?? '/';
+}
 
 foreach ($routes as $route => $target) {
     if (preg_match($route, $url, $match_args)) {


### PR DESCRIPTION
- Adds a new method to the Model class, `Model::update`, whiches takes an associative `array` `$params` — the fields to update along with their new values.
- Lucid now uses `REQUEST_URI` to get the current URL, instead of `PATH_INFO`. For projects that rely on the old `PATH_INFO`, the variable `$USE_RELATIVE_PATH_INFO` can be set to `true` before loading Lucid.
- Adds a use of the new `Model::update` method in the example application.
- Method access modifiers have been added to the example app as well as to the base project that gets cloned with the `lucid init` command.